### PR TITLE
Make data model tiers more configurable

### DIFF
--- a/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
@@ -14,7 +14,7 @@ public class HostileConfig {
         simPowerCap = cfg.getInt("Sim Chamber Power Cap", "power", simPowerCap, 1, Integer.MAX_VALUE, "The maximum FE stored in the Simulation Chamber.");
         fabPowerCap = cfg.getInt("Loot Fab Power Cap", "power", fabPowerCap, 1, Integer.MAX_VALUE, "The maximum FE stored in the Loot Fabricator.");
         fabPowerCost = cfg.getInt("Loot Fab Power Cost", "power", fabPowerCost, 0, Integer.MAX_VALUE, "The FE/t cost of the Loot Fabricator.");
-        continuousAccuracy = cfg.getBoolean("Continuous Accuracy", "accuracy", continuousAccuracy, "If true, the accuracy of the model increases as it gains progress towards the next tier. If false, always uses the base accuracy of the current tier.");
+        continuousAccuracy = cfg.getBoolean("Continuous Accuracy", "models", continuousAccuracy, "If true, the accuracy of the model increases as it gains progress towards the next tier. If false, always uses the base accuracy of the current tier.");
         if (cfg.hasChanged()) cfg.save();
     }
 

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
@@ -1,5 +1,6 @@
 package dev.shadowsoffire.hostilenetworks;
 
+import dev.shadowsoffire.hostilenetworks.data.ModelTier;
 import dev.shadowsoffire.placebo.config.Configuration;
 
 public class HostileConfig {

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
@@ -7,12 +7,14 @@ public class HostileConfig {
     public static int simPowerCap = 2000000;
     public static int fabPowerCap = 1000000;
     public static int fabPowerCost = 256;
+    public static boolean continuousAccuracy = false;
 
     public static void load() {
         Configuration cfg = new Configuration(HostileNetworks.MODID);
         simPowerCap = cfg.getInt("Sim Chamber Power Cap", "power", simPowerCap, 1, Integer.MAX_VALUE, "The maximum FE stored in the Simulation Chamber.");
         fabPowerCap = cfg.getInt("Loot Fab Power Cap", "power", fabPowerCap, 1, Integer.MAX_VALUE, "The maximum FE stored in the Loot Fabricator.");
         fabPowerCost = cfg.getInt("Loot Fab Power Cost", "power", fabPowerCost, 0, Integer.MAX_VALUE, "The FE/t cost of the Loot Fabricator.");
+        continuousAccuracy = cfg.getBoolean("Continuous Accuracy", "accuracy", continuousAccuracy, "If true, the accuracy of the model increases as it gains progress towards the next tier. If false, always uses the base accuracy of the current tier.");
         if (cfg.hasChanged()) cfg.save();
     }
 

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
@@ -8,6 +8,7 @@ public class HostileConfig {
     public static int fabPowerCap = 1000000;
     public static int fabPowerCost = 256;
     public static boolean continuousAccuracy = false;
+    public static int simModelUpgrade = 0;
 
     public static void load() {
         Configuration cfg = new Configuration(HostileNetworks.MODID);
@@ -15,6 +16,7 @@ public class HostileConfig {
         fabPowerCap = cfg.getInt("Loot Fab Power Cap", "power", fabPowerCap, 1, Integer.MAX_VALUE, "The maximum FE stored in the Loot Fabricator.");
         fabPowerCost = cfg.getInt("Loot Fab Power Cost", "power", fabPowerCost, 0, Integer.MAX_VALUE, "The FE/t cost of the Loot Fabricator.");
         continuousAccuracy = cfg.getBoolean("Continuous Accuracy", "models", continuousAccuracy, "If true, the accuracy of the model increases as it gains progress towards the next tier. If false, always uses the base accuracy of the current tier.");
+        simModelUpgrade = cfg.getInt("Sim Chamber Upgrades Model", "models", simModelUpgrade, 0,2, "Whether the Simulation Chamber will upgrade the data on a model. (0 = No, 1 = Yes, 2 = Only up to tier boundaries)");
         if (cfg.hasChanged()) cfg.save();
     }
 

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
@@ -7,16 +7,22 @@ public class HostileConfig {
     public static int simPowerCap = 2000000;
     public static int fabPowerCap = 1000000;
     public static int fabPowerCost = 256;
-    public static boolean continuousAccuracy = false;
-    public static int simModelUpgrade = 0;
+
+    public static boolean rightClickToAttune = true;
+    public static int simModelUpgrade = 1;
+    public static boolean killModelUpgrade = true;
+    public static boolean continuousAccuracy = true;
 
     public static void load() {
         Configuration cfg = new Configuration(HostileNetworks.MODID);
         simPowerCap = cfg.getInt("Sim Chamber Power Cap", "power", simPowerCap, 1, Integer.MAX_VALUE, "The maximum FE stored in the Simulation Chamber.");
         fabPowerCap = cfg.getInt("Loot Fab Power Cap", "power", fabPowerCap, 1, Integer.MAX_VALUE, "The maximum FE stored in the Loot Fabricator.");
         fabPowerCost = cfg.getInt("Loot Fab Power Cost", "power", fabPowerCost, 0, Integer.MAX_VALUE, "The FE/t cost of the Loot Fabricator.");
+
+        rightClickToAttune = cfg.getBoolean("Right Click To Attune", "models", rightClickToAttune, "If true, right clicking a blank data model on a mob will attune it to that mob. If disabled, you will need to provide players with a way to get attuned models!");
+        simModelUpgrade = cfg.getInt("Sim Chamber Upgrades Model", "models", simModelUpgrade, 0, 2, "Whether the Simulation Chamber will upgrade the data on a model. (0 = No, 1 = Yes, 2 = Only up to tier boundaries)");
+        killModelUpgrade = cfg.getBoolean("Killing Upgrades Model", "models", killModelUpgrade, "Whether killing mobs will upgrade the data on a model. Note: If you disable this, be sure to add a way for players to get non-Faulty models!");
         continuousAccuracy = cfg.getBoolean("Continuous Accuracy", "models", continuousAccuracy, "If true, the accuracy of the model increases as it gains progress towards the next tier. If false, always uses the base accuracy of the current tier.");
-        simModelUpgrade = cfg.getInt("Sim Chamber Upgrades Model", "models", simModelUpgrade, 0,2, "Whether the Simulation Chamber will upgrade the data on a model. (0 = No, 1 = Yes, 2 = Only up to tier boundaries)");
         if (cfg.hasChanged()) cfg.save();
     }
 

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/HostileConfig.java
@@ -1,6 +1,5 @@
 package dev.shadowsoffire.hostilenetworks;
 
-import dev.shadowsoffire.hostilenetworks.data.ModelTier;
 import dev.shadowsoffire.placebo.config.Configuration;
 
 public class HostileConfig {

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/HostileEvents.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/HostileEvents.java
@@ -38,6 +38,7 @@ public class HostileEvents {
 
     @SubscribeEvent
     public static void modelAttunement(EntityInteractSpecific e) {
+        if (!HostileConfig.rightClickToAttune) return;
         Player player = e.getEntity();
         ItemStack stack = player.getItemInHand(e.getHand());
         if (stack.getItem() == Hostile.Items.BLANK_DATA_MODEL.get()) {
@@ -62,6 +63,7 @@ public class HostileEvents {
 
     @SubscribeEvent
     public static void kill(LivingDeathEvent e) {
+        if (!HostileConfig.killModelUpgrade) return;
         Entity src = e.getSource().getEntity();
         if (src instanceof ServerPlayer p) {
             p.getInventory().items.stream().filter(s -> s.getItem() == Items.DEEP_LEARNER.get()).forEach(dl -> updateModels(dl, e.getEntity().getType(), 0));

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/HostileNetworks.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/HostileNetworks.java
@@ -1,5 +1,6 @@
 package dev.shadowsoffire.hostilenetworks;
 
+import dev.shadowsoffire.hostilenetworks.data.ModelTierRegistry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -42,5 +43,10 @@ public class HostileNetworks {
                 Items.END_PREDICTION, Items.TWILIGHT_PREDICTION, Items.DATA_MODEL, Items.PREDICTION);
         });
         DataModelRegistry.INSTANCE.registerToBus();
+        ModelTierRegistry.INSTANCE.registerToBus();
+    }
+
+    public static ResourceLocation loc(String path) {
+        return new ResourceLocation(MODID, path);
     }
 }

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/data/CachedModel.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/data/CachedModel.java
@@ -1,5 +1,6 @@
 package dev.shadowsoffire.hostilenetworks.data;
 
+import dev.shadowsoffire.hostilenetworks.HostileConfig;
 import dev.shadowsoffire.hostilenetworks.item.DataModelItem;
 import dev.shadowsoffire.hostilenetworks.util.ClientEntityCache;
 import dev.shadowsoffire.placebo.reload.DynamicHolder;
@@ -70,6 +71,7 @@ public class CachedModel {
     }
 
     public float getAccuracy() {
+        if (!HostileConfig.continuousAccuracy) return this.tier.accuracy();
         ModelTier next = this.tier.next();
         if (this.tier == next) return next.accuracy();
         int diff = this.getNextTierData() - this.getTierData();

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/data/CachedModel.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/data/CachedModel.java
@@ -71,10 +71,10 @@ public class CachedModel {
 
     public float getAccuracy() {
         ModelTier next = this.tier.next();
-        if (this.tier == next) return next.accuracy;
+        if (this.tier == next) return next.accuracy();
         int diff = this.getNextTierData() - this.getTierData();
-        float tDiff = next.accuracy - this.tier.accuracy;
-        return this.tier.accuracy + tDiff * (diff - (this.getNextTierData() - this.data)) / diff;
+        float tDiff = next.accuracy() - this.tier.accuracy();
+        return this.tier.accuracy() + tDiff * (diff - (this.getNextTierData() - this.data)) / diff;
     }
 
     public int getKillsNeeded() {

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/data/ModelTierRegistry.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/data/ModelTierRegistry.java
@@ -1,0 +1,56 @@
+package dev.shadowsoffire.hostilenetworks.data;
+
+import com.google.common.base.Preconditions;
+import dev.shadowsoffire.hostilenetworks.HostileNetworks;
+import dev.shadowsoffire.hostilenetworks.data.ModelTier.TierData;
+import dev.shadowsoffire.placebo.reload.DynamicRegistry;
+import net.minecraft.resources.ResourceLocation;
+
+public class ModelTierRegistry extends DynamicRegistry<TierData> {
+
+    public static final ModelTierRegistry INSTANCE = new ModelTierRegistry();
+
+    public ModelTierRegistry() {
+        super(HostileNetworks.LOGGER, "model_tiers", true, false);
+
+        for (ModelTier tier : ModelTier.values()) {
+            holder(HostileNetworks.loc(tier.name));
+        }
+    }
+
+    @Override
+    protected void onReload() {
+        super.onReload();
+        // check that the builtin tiers and only the builtin tiers exist
+        for (ModelTier tier : ModelTier.values()) {
+            String name = tier.name;
+            Preconditions.checkNotNull(getValue(HostileNetworks.loc(name)), "Missing builtin model tier: " + name);
+        }
+
+        Preconditions.checkArgument(this.getValues().size() == ModelTier.values().length, "Registration of additional model tiers is currently not supported!");
+
+        // update the builtin tiers (separate step so that we don't have a half-updated state if validation fails)
+        for (ModelTier tier : ModelTier.values()) {
+            tier.updateData(this.getValue(HostileNetworks.loc(tier.name)));
+        }
+    }
+
+    @Override
+    protected void registerBuiltinCodecs() {
+        this.registerDefaultCodec(HostileNetworks.loc("tier_data"), TierData.CODEC);
+    }
+
+    @Override
+    protected void validateItem(ResourceLocation key, TierData value) {
+        super.validateItem(key, value);
+        if (isTier(key, ModelTier.FAULTY)) {
+            Preconditions.checkArgument(value.requiredData() == 0, "Faulty tier cannot require any data!");
+        } else if (isTier(key, ModelTier.SELF_AWARE)) {
+            Preconditions.checkArgument(value.dataPerKill() == 0, "Self-aware tier cannot be upgraded further!");
+        }
+    }
+
+    private boolean isTier(ResourceLocation key, ModelTier tier) {
+        return key.getPath().equals(tier.name);
+    }
+}

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/gui/DeepLearnerScreen.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/gui/DeepLearnerScreen.java
@@ -259,12 +259,12 @@ public class DeepLearnerScreen extends PlaceboContainerScreen<DeepLearnerContain
         this.addText(I18n.get("hostilenetworks.gui.tier"), Color.WHITE, false);
         ModelTier tier = cache.getTier();
         ModelTier next = tier.next();
-        this.addText(I18n.get("hostilenetworks.tier." + tier.name), tier.color.getColor());
+        this.addText(I18n.get("hostilenetworks.tier." + tier.name), tier.color());
         this.addText(I18n.get("hostilenetworks.gui.accuracy"), Color.WHITE, false);
-        this.addText(fmt.format(cache.getAccuracy()), tier.color.getColor());
+        this.addText(fmt.format(cache.getAccuracy()), tier.color());
         if (tier != next) {
             this.addText(I18n.get("hostilenetworks.gui.next_tier"), Color.WHITE, false);
-            this.addText(I18n.get("hostilenetworks.tier." + next.name), next.color.getColor(), false);
+            this.addText(I18n.get("hostilenetworks.tier." + next.name), next.color(), false);
             this.addText(I18n.get("hostilenetworks.gui.next_tier2", cache.getKillsNeeded()), Color.WHITE, false);
             this.addText(I18n.get("hostilenetworks.gui.kill" + (cache.getKillsNeeded() > 1 ? "s" : "")), Color.WHITE);
         }

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/gui/SimChamberScreen.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/gui/SimChamberScreen.java
@@ -83,7 +83,7 @@ public class SimChamberScreen extends PlaceboContainerScreen<SimChamberContainer
             gfx.drawString(this.font, msg, xOff, 9 + this.font.lineHeight + 3, Color.WHITE);
             xOff += this.font.width(msg);
             msg = I18n.get("hostilenetworks.tier." + cModel.getTier().name);
-            gfx.drawString(this.font, msg, xOff, 9 + this.font.lineHeight + 3, cModel.getTier().color.getColor());
+            gfx.drawString(this.font, msg, xOff, 9 + this.font.lineHeight + 3, cModel.getTier().color());
 
             xOff = 18;
             msg = I18n.get("hostilenetworks.gui.accuracy");
@@ -91,7 +91,7 @@ public class SimChamberScreen extends PlaceboContainerScreen<SimChamberContainer
             xOff += this.font.width(msg);
             DecimalFormat fmt = new DecimalFormat("##.##%");
             msg = fmt.format(cModel.getAccuracy());
-            gfx.drawString(this.font, msg, xOff, 9 + (this.font.lineHeight + 3) * 2, cModel.getTier().color.getColor());
+            gfx.drawString(this.font, msg, xOff, 9 + (this.font.lineHeight + 3) * 2, cModel.getTier().color());
         }
         int left = 29;
         int top = 51;

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/jei/SimChamberCategory.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/jei/SimChamberCategory.java
@@ -94,9 +94,9 @@ public class SimChamberCategory implements IRecipeCategory<TickingDataModelWrapp
         }
         Component comp = recipe.currentTier.getComponent();
         width = font.width(comp);
-        gfx.drawString(font, recipe.currentTier.getComponent(), 33 - width / 2, 30, recipe.currentTier.color.getColor());
+        gfx.drawString(font, recipe.currentTier.getComponent(), 33 - width / 2, 30, recipe.currentTier.color());
         DecimalFormat fmt = new DecimalFormat("##.##%");
-        String msg = fmt.format(recipe.currentTier.accuracy);
+        String msg = fmt.format(recipe.currentTier.accuracy());
         width = font.width(msg);
         gfx.drawString(font, msg, 114 - width, 30, Color.WHITE, true);
     }

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/tile/SimChamberTileEntity.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/tile/SimChamberTileEntity.java
@@ -115,7 +115,7 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
                         ModelTier tier = this.currentModel.getTier();
                         if (tier != tier.next() && HostileConfig.simModelUpgrade > 0) {
                             int newData = this.currentModel.getData() + 1;
-                            if (!(HostileConfig.simModelUpgrade == 2 || newData > this.currentModel.getNextTierData())) {
+                            if (!(HostileConfig.simModelUpgrade == 2 && newData > this.currentModel.getNextTierData())) {
                                 this.currentModel.setData(newData);
                             }
                         }

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/tile/SimChamberTileEntity.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/tile/SimChamberTileEntity.java
@@ -113,8 +113,11 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
                             else stk.grow(1);
                         }
                         ModelTier tier = this.currentModel.getTier();
-                        if (tier != tier.next()) {
-                            this.currentModel.setData(this.currentModel.getData() + 1);
+                        if (tier != tier.next() && HostileConfig.simModelUpgrade > 0) {
+                            int newData = this.currentModel.getData() + 1;
+                            if (!(HostileConfig.simModelUpgrade == 2 || newData > this.currentModel.getNextTierData())) {
+                                this.currentModel.setData(newData);
+                            }
                         }
                         DataModelItem.setIters(model, DataModelItem.getIters(model) + 1);
                         this.setChanged();

--- a/src/main/resources/data/hostilenetworks/model_tiers/advanced.json
+++ b/src/main/resources/data/hostilenetworks/model_tiers/advanced.json
@@ -1,0 +1,6 @@
+{
+  "required_data": 54,
+  "data_per_kill": 10,
+  "color": "blue",
+  "accuracy": 0.22
+}

--- a/src/main/resources/data/hostilenetworks/model_tiers/basic.json
+++ b/src/main/resources/data/hostilenetworks/model_tiers/basic.json
@@ -1,0 +1,6 @@
+{
+  "required_data": 6,
+  "data_per_kill": 4,
+  "color": "green",
+  "accuracy": 0.05
+}

--- a/src/main/resources/data/hostilenetworks/model_tiers/faulty.json
+++ b/src/main/resources/data/hostilenetworks/model_tiers/faulty.json
@@ -1,0 +1,6 @@
+{
+  "required_data": 0,
+  "data_per_kill": 0,
+  "color": "dark_gray",
+  "accuracy": 0.01
+}

--- a/src/main/resources/data/hostilenetworks/model_tiers/self_aware.json
+++ b/src/main/resources/data/hostilenetworks/model_tiers/self_aware.json
@@ -1,0 +1,6 @@
+{
+  "required_data": 1254,
+  "data_per_kill": 0,
+  "color": "gold",
+  "accuracy": 0.995
+}

--- a/src/main/resources/data/hostilenetworks/model_tiers/superior.json
+++ b/src/main/resources/data/hostilenetworks/model_tiers/superior.json
@@ -1,0 +1,6 @@
+{
+  "required_data": 354,
+  "data_per_kill": 18,
+  "color": "light_purple",
+  "accuracy": 0.65
+}


### PR DESCRIPTION
This introduces some of the changes I mentioned in #47 by using Placebo's dynamic registry system (though currently, the registry itself isn't really "dynamic", you can only change the data of the existing tiers; I figured making the system fully dynamic would be too big of a change for now)

One more thing I would like to try is add a config option to make model accuracy discrete instead of continuous, ~~but that's gonna be for another PR~~ nvm that was so easy to add I just did that real quick