### PR TITLE
Added Breeze model

### DIFF
--- a/src/main/resources/assets/hostilenetworks/lang/en_us.json
+++ b/src/main/resources/assets/hostilenetworks/lang/en_us.json
@@ -111,8 +111,9 @@
 	"hostilenetworks.trivia.snow_golem": "The mind of a pumpkin, yet again.\nHe probably couldn't count to ten.",
 	"hostilenetworks.trivia.cod": "Fish.\n\n\nFiiiiiiish.",
 	"hostilenetworks.trivia.pig": "The pig is an interesting case.\nWorse than a cow for drops,\nand worse than a horse for riding.\nMaybe the killing is kindness...",
-	
+
 	"_comment": "Vanilla Hostiles",
+	"hostilenetworks.trivia.breeze": "An airy relative of the Blaze,\nBreezes can only be found\nwithin the confines of a Trial Chamber.",
 	"hostilenetworks.trivia.blaze": "Bring buckets and watch in despair\nas it evaporates, and everything is\non fire. You are on fire.",
 	"hostilenetworks.trivia.creeper": "An inverse architect by trade.\nGenerally misunderstood.",
 	"hostilenetworks.trivia.drowned": "An undead man who has\ndefied death again.\nSomehow he learned to use a Trident.",

--- a/src/main/resources/data/hostilenetworks/data_models/breeze.json
+++ b/src/main/resources/data/hostilenetworks/data_models/breeze.json
@@ -1,0 +1,21 @@
+{
+    "entity": "minecraft:breeze",
+    "name": {
+        "translate": "entity.minecraft.breeze",
+        "color": "#3D4167"
+    },
+    "sim_cost": 256,
+    "input": {
+        "item": "hostilenetworks:prediction_matrix"
+    },
+    "base_drop": {
+        "id": "hostilenetworks:overworld_prediction"
+    },
+    "trivia": "hostilenetworks.trivia.breeze",
+    "fabricator_drops": [
+        {
+            "id": "minecraft:breeze_rod",
+            "count": 16
+        }
+    ]
+}

--- a/src/main/resources/data/hostilenetworks/data_models/hoglin.json
+++ b/src/main/resources/data/hostilenetworks/data_models/hoglin.json
@@ -1,6 +1,8 @@
 {
     "entity": "minecraft:hoglin",
-    "variants": [],
+    "variants": [
+        "minecraft:zoglin"
+    ],
     "name": {
         "translate": "entity.minecraft.hoglin",
         "color": "#E8A074"

--- a/src/main/resources/data/hostilenetworks/data_models/skeleton.json
+++ b/src/main/resources/data/hostilenetworks/data_models/skeleton.json
@@ -1,7 +1,8 @@
 {
     "entity": "minecraft:skeleton",
     "variants": [
-        "minecraft:stray"
+        "minecraft:stray",
+        "minecraft:bogged"
     ],
     "name": {
         "translate": "entity.minecraft.skeleton",

--- a/src/main/resources/data/hostilenetworks/data_models/slime.json
+++ b/src/main/resources/data/hostilenetworks/data_models/slime.json
@@ -26,10 +26,6 @@
             "count": 32
         },
         {
-            "id": "minecraft:slime_block",
-            "count": 8
-        },
-        {
             "id": "reliquary:slime_pearl",
             "optional": true,
             "count": 2


### PR DESCRIPTION
Also added the [Bogged](https://minecraft.wiki/w/Bogged) as a Skeleton variant, and balanced Slimes by removing the Slime Block output (which gives 72 Slime Balls vs. the intended 32).

Also added the [Zoglin](https://minecraft.wiki/w/Zoglin) as a Hoglin variant.