### PR TITLE
Fix warden data model

### DIFF
--- a/src/main/resources/data/hostilenetworks/data_models/warden.json
+++ b/src/main/resources/data/hostilenetworks/data_models/warden.json
@@ -30,13 +30,17 @@
             "count": 1
         },
         {
-            "id": "apotheosis:warden_tendril",
+            "id": "apothic_enchanting:warden_tendril",
             "optional": true,
             "count": 1
         },
         {
             "id": "minecraft:echo_shard",
             "count": 2
+        },
+        {
+            "id": "minecraft:sculk_catalyst",
+            "count": 4
         }
     ]
 }


### PR DESCRIPTION
- In 1.21 apotheosis was splited into multiple different mods. Now modid of warden tendril is `apothic_enchanting`.
- Add vanilla drop sculk catalyst to loots of warden.