### PR TITLE
Turn off redstone conductivity.

### DIFF
--- a/src/main/java/dev/shadowsoffire/hostilenetworks/Hostile.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/Hostile.java
@@ -37,8 +37,8 @@ public class Hostile {
     private static final DeferredHelper R = DeferredHelper.create(HostileNetworks.MODID);
 
     public static class Blocks {
-        public static final Holder<Block> SIM_CHAMBER = R.block("sim_chamber", SimChamberBlock::new, p -> p.lightLevel(s -> 1).strength(4, 3000).noOcclusion());
-        public static final Holder<Block> LOOT_FABRICATOR = R.block("loot_fabricator", LootFabBlock::new, p -> p.lightLevel(s -> 1).strength(4, 3000).noOcclusion());
+        public static final Holder<Block> SIM_CHAMBER = R.block("sim_chamber", SimChamberBlock::new);
+        public static final Holder<Block> LOOT_FABRICATOR = R.block("loot_fabricator", LootFabBlock::new);
 
         private static void bootstrap() {}
     }

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/block/LootFabBlock.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/block/LootFabBlock.java
@@ -22,8 +22,12 @@ import net.minecraft.world.phys.BlockHitResult;
 
 public class LootFabBlock extends HorizontalDirectionalBlock implements TickingEntityBlock {
 
-    public LootFabBlock(Properties props) {
-        super(props);
+    public LootFabBlock() {
+        super(Properties.of()
+                .lightLevel(s -> 1)
+                .strength(4, 3000)
+                .isRedstoneConductor((s, g, p) -> false)
+                .noOcclusion());
         this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH));
     }
 

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/block/SimChamberBlock.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/block/SimChamberBlock.java
@@ -22,8 +22,12 @@ import net.minecraft.world.phys.BlockHitResult;
 
 public class SimChamberBlock extends HorizontalDirectionalBlock implements TickingEntityBlock {
 
-    public SimChamberBlock(Properties props) {
-        super(props);
+    public SimChamberBlock() {
+        super(Properties.of()
+                .lightLevel(s -> 1)
+                .strength(4, 3000)
+                .isRedstoneConductor((s, g, p) -> false)
+                .noOcclusion());
         this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH));
     }
 


### PR DESCRIPTION
Fixes #87 and cleans up the constructors to use the more readable `Properties.of()` style.