### PR TITLE
Training/Inference (separate drops vs model progression)

### DIFF
--- a/src/main/java/dev/shadowsoffire/hostilenetworks/gui/SimChamberContainer.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/gui/SimChamberContainer.java
@@ -12,6 +12,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 
+
 public class SimChamberContainer extends BlockEntityMenu<SimChamberTileEntity> {
 
     public SimChamberContainer(int id, Inventory pInv, BlockPos pos) {
@@ -32,6 +33,7 @@ public class SimChamberContainer extends BlockEntityMenu<SimChamberTileEntity> {
     public boolean stillValid(Player pPlayer) {
         return pPlayer.level().getBlockState(this.pos).is(Hostile.Blocks.SIM_CHAMBER);
     }
+    public boolean isTrainingMode() { return this.tile.isTrainingMode(); }
 
     public int getEnergyStored() {
         return this.tile.getEnergyStored();
@@ -62,6 +64,9 @@ public class SimChamberContainer extends BlockEntityMenu<SimChamberTileEntity> {
         if (id >= 0 && id <= 2) {
             RedstoneState state = RedstoneState.values()[id];
             this.setRedstoneState(state);
+            return true;
+        } else if (id == 3) {
+            this.tile.setTrainingMode(!this.tile.isTrainingMode());
             return true;
         }
         return super.clickMenuButton(player, id);

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/gui/SimChamberScreen.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/gui/SimChamberScreen.java
@@ -81,6 +81,14 @@ public class SimChamberScreen extends PlaceboContainerScreen<SimChamberContainer
                 gfx.renderComponentTooltip(this.font, txt, pX, pY);
             }
         }
+
+        else if (this.isHovering(228, 20, 18, 18, pX, pY)) {
+            Component tip = this.menu.isTrainingMode()
+                    ? Component.translatable("hostilenetworks.gui.mode.training")
+                    : Component.translatable("hostilenetworks.gui.mode.inference");
+            gfx.renderTooltip(this.font, tip, pX, pY);
+        }
+
         else if (this.isHovering(229, 1, 16, 16, pX, pY)) {
             gfx.renderTooltip(this.font, Component.translatable(this.menu.getRedstoneState().getKey()), pX, pY);
         }
@@ -168,17 +176,36 @@ public class SimChamberScreen extends PlaceboContainerScreen<SimChamberContainer
             float speed = 0.65F;
             this.body.clear();
             int iters = DataModelItem.getIters(this.menu.getSlot(0).getItem());
+
+            DataModelInstance tier = new DataModelInstance(this.menu.getSlot(0).getItem(),0);
+            Component tierComp = tier.isValid() ? tier.getTier().getComponent() : ERROR;
+
+            boolean simTraining = SimChamberScreen.this.menu.isTrainingMode();
             for (int i = 0; i < 7; i++) {
-                Component txt = Component.translatable("hostilenetworks.run." + i, iters);
-                this.body.addLine(txt, speed);
-                if (i == 0) {
-                    Component version = Component.literal("v" + HostileNetworks.VERSION).withStyle(ChatFormatting.GOLD);
-                    this.body.continueLine(version, speed);
+                if (simTraining) {
+                    Component txt = Component.translatable("hostilenetworks.run.training." + i, iters);
+                    this.body.addLine(txt, speed);
+                    if (i == 0) {
+                        Component version = Component.literal("v" + HostileNetworks.VERSION).withStyle(ChatFormatting.GOLD);
+                        this.body.continueLine(version, speed);
+                    }
                 }
-                else if (i == 5) {
-                    String key = "hostilenetworks.color_text." + (this.menu.didPredictionSucceed() ? "success" : "failed");
-                    Component status = Component.translatable(key).withStyle(this.menu.didPredictionSucceed() ? ChatFormatting.GOLD : ChatFormatting.RED);
-                    this.body.continueLine(status, speed);
+                else {
+                    Component txt = Component.translatable("hostilenetworks.run.inference." + i, iters);
+                    this.body.addLine(txt, speed);
+                    if (i == 0) {
+                        Component version = Component.literal("v" + HostileNetworks.VERSION).withStyle(ChatFormatting.GOLD);
+                        this.body.continueLine(version, speed);
+
+                    }
+                    else if (i == 1) {
+                        this.body.continueLine(tierComp, speed);
+                    }
+                    else if (i == 5) {
+                        String key = "hostilenetworks.color_text." + (this.menu.didPredictionSucceed() ? "success" : "failed");
+                        Component status = Component.translatable(key).withStyle(this.menu.didPredictionSucceed() ? ChatFormatting.GOLD : ChatFormatting.RED);
+                        this.body.continueLine(status, speed);
+                    }
                 }
             }
             this.body.setTicks(ticks);
@@ -242,9 +269,16 @@ public class SimChamberScreen extends PlaceboContainerScreen<SimChamberContainer
 
         @Override
         protected void renderWidget(GuiGraphics gfx, int mouseX, int mouseY, float partialTick) {
-            // draw a single letter so you can see it exists
+            RenderSystem.enableBlend();
+            RenderSystem.enableDepthTest();
+            gfx.setColor(1f, 1f, 1f, 1f);
+            gfx.blit(BASE, this.getX(), this.getY(), 0, 141, 18, 18, 256, 256);
             String s = SimChamberScreen.this.menu.isTrainingMode() ? "T" : "I";
-            gfx.drawString(SimChamberScreen.this.font, s, this.getX() + 6, this.getY() + 5, 0xFFFFFF, true);
+            int x = this.getX() + 6 + ("I".equals(s) ? 1 : 0); //I needs to be to the right by 1 pixel, otherwise looks ugly
+            int y = this.getY() + 5;
+            gfx.drawString(SimChamberScreen.this.font, s, x, y, 0xFFFFFF, true);
+
+
         }
     }
 

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/gui/SimChamberScreen.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/gui/SimChamberScreen.java
@@ -31,6 +31,8 @@ public class SimChamberScreen extends PlaceboContainerScreen<SimChamberContainer
     public static final int MAX_TEXT_WIDTH = 174;
     public static final float RUNTIME_TEXT_SPEED = 0.65F;
 
+
+
     private static final ResourceLocation BASE = HostileNetworks.loc("textures/gui/sim_chamber.png");
     private static final ResourceLocation PLAYER = HostileNetworks.loc("textures/gui/default_gui.png");
 
@@ -48,6 +50,7 @@ public class SimChamberScreen extends PlaceboContainerScreen<SimChamberContainer
     public void init() {
         super.init();
         addRenderableWidget(new RedstoneButton(this.getGuiLeft() + 228, this.getGuiTop()));
+        addRenderableWidget(new ModeButton(this.getGuiLeft() + 228, this.getGuiTop() + 20));
         this.body = new TickableTextList(this.minecraft.font, MAX_TEXT_WIDTH);
         this.lastFailState = FailureState.NONE;
         this.runtimeTextLoaded = false;
@@ -218,5 +221,34 @@ public class SimChamberScreen extends PlaceboContainerScreen<SimChamberContainer
             guiGraphics.blit(SimChamberScreen.this.menu.getRedstoneState().getResourceLocation(), this.getX() + 1, this.getY() + 1, 0, 0, 16, 16, 16, 16);
         }
     }
+
+    private class ModeButton extends AbstractWidget {
+
+        public ModeButton(int x, int y) {
+            super(x, y, 18, 18, Component.empty());
+        }
+
+        @Override
+        public void onClick(double mouseX, double mouseY) {
+            SimChamberScreen scn = SimChamberScreen.this;
+            scn.minecraft.gameMode.handleInventoryButtonClick(scn.menu.containerId, 3);
+        }
+
+
+        @Override
+        protected void updateWidgetNarration(NarrationElementOutput output) {
+            this.defaultButtonNarrationText(output);
+        }
+
+        @Override
+        protected void renderWidget(GuiGraphics gfx, int mouseX, int mouseY, float partialTick) {
+            // draw a single letter so you can see it exists
+            String s = SimChamberScreen.this.menu.isTrainingMode() ? "T" : "I";
+            gfx.drawString(SimChamberScreen.this.font, s, this.getX() + 6, this.getY() + 5, 0xFFFFFF, true);
+        }
+    }
+
+
+
 
 }

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/tile/SimChamberTileEntity.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/tile/SimChamberTileEntity.java
@@ -35,6 +35,8 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
     protected DataModelInstance currentModel = DataModelInstance.EMPTY;
     protected int runtime = 0;
 
+    protected boolean trainingMode = true;
+
     /**
      * The amount of successful predictions for the current simulation run.
      * <p>
@@ -52,6 +54,7 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
         this.data.addData(() -> this.predictionSuccess, v -> this.predictionSuccess = v);
         this.data.addData(() -> this.failState.ordinal(), v -> this.failState = FailureState.values()[v]);
         this.data.addData(() -> this.redstoneState.ordinal(), v -> this.redstoneState = RedstoneState.values()[v]);
+        this.data.addData(() -> this.trainingMode ? 1 : 0, v -> this.trainingMode = v != 0);
         this.data.addEnergy(this.energy);
         this.energy.setMaxExtract(0);
     }
@@ -71,6 +74,7 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
         tag.putInt("predSuccess", this.predictionSuccess);
         tag.putInt("failState", this.failState.ordinal());
         tag.putInt("redstoneState", this.redstoneState.ordinal());
+        tag.putBoolean("trainingMode", this.trainingMode);
     }
 
     @Override
@@ -88,6 +92,7 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
         this.predictionSuccess = tag.getInt("predSuccess");
         this.failState = FailureState.values()[tag.getInt("failState")];
         this.redstoneState = RedstoneState.values()[tag.getInt("redstoneState")];
+        this.trainingMode = tag.getBoolean("trainingMode");
     }
 
     @Override
@@ -122,26 +127,30 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
                     if (this.getRedstoneState().matches(level.hasNeighborSignal(worldPosition))) {
                         this.failState = FailureState.NONE;
                         if (--this.runtime == 0) {
-                            ItemStack stk = this.inventory.getStackInSlot(2);
-                            if (stk.isEmpty()) this.inventory.setStackInSlot(2, this.currentModel.getModel().baseDrop().copy());
-                            else stk.grow(1);
-                            if (this.predictionSuccess > 0) {
-                                stk = this.inventory.getStackInSlot(3);
-                                if (stk.isEmpty()) {
-                                    this.inventory.setStackInSlot(3, this.currentModel.getPredictionDrop().copyWithCount(this.predictionSuccess));
-                                }
-                                else {
-                                    stk.grow(this.predictionSuccess);
-                                }
-                            }
-                            ModelTier tier = this.currentModel.getTier();
-                            if (!tier.isMax() && HostileConfig.simModelUpgrade > 0) {
-                                int newData = this.currentModel.getData() + 1;
-                                if (!(HostileConfig.simModelUpgrade == 2 && newData > this.currentModel.getNextTierData())) {
-                                    this.currentModel.setData(newData);
+                            if (!this.trainingMode) { //Inference
+                                ItemStack stk = this.inventory.getStackInSlot(2);
+                                if (stk.isEmpty())
+                                    this.inventory.setStackInSlot(2, this.currentModel.getModel().baseDrop().copy());
+                                else stk.grow(1);
+                                if (this.predictionSuccess > 0) {
+                                    stk = this.inventory.getStackInSlot(3);
+                                    if (stk.isEmpty()) {
+                                        this.inventory.setStackInSlot(3, this.currentModel.getPredictionDrop().copyWithCount(this.predictionSuccess));
+                                    } else {
+                                        stk.grow(this.predictionSuccess);
+                                    }
                                 }
                             }
-                            DataModelItem.setIters(model, DataModelItem.getIters(model) + 1);
+                            else { // Training
+                                ModelTier tier = this.currentModel.getTier();
+                                if (!tier.isMax() && HostileConfig.simModelUpgrade > 0) {
+                                    int newData = this.currentModel.getData() + 1;
+                                    if (!(HostileConfig.simModelUpgrade == 2 && newData > this.currentModel.getNextTierData())) {
+                                        this.currentModel.setData(newData);
+                                    }
+                                }
+                                DataModelItem.setIters(model, DataModelItem.getIters(model) + 1);
+                            }
                             this.setChanged();
                         }
                         else if (this.runtime != 0) {
@@ -249,6 +258,15 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
 
     public RedstoneState getRedstoneState() {
         return this.redstoneState;
+    }
+
+    public boolean isTrainingMode() {
+        return this.trainingMode;
+    }
+
+    public void setTrainingMode(boolean trainingMode) {
+        this.trainingMode = trainingMode;
+        this.setChanged();
     }
 
     public class SimItemHandler extends InternalItemHandler {

--- a/src/main/java/dev/shadowsoffire/hostilenetworks/tile/SimChamberTileEntity.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/tile/SimChamberTileEntity.java
@@ -35,7 +35,7 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
     protected DataModelInstance currentModel = DataModelInstance.EMPTY;
     protected int runtime = 0;
 
-    protected boolean trainingMode = true;
+    protected boolean trainingMode = false;
 
     /**
      * The amount of successful predictions for the current simulation run.
@@ -127,21 +127,7 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
                     if (this.getRedstoneState().matches(level.hasNeighborSignal(worldPosition))) {
                         this.failState = FailureState.NONE;
                         if (--this.runtime == 0) {
-                            if (!this.trainingMode) { //Inference
-                                ItemStack stk = this.inventory.getStackInSlot(2);
-                                if (stk.isEmpty())
-                                    this.inventory.setStackInSlot(2, this.currentModel.getModel().baseDrop().copy());
-                                else stk.grow(1);
-                                if (this.predictionSuccess > 0) {
-                                    stk = this.inventory.getStackInSlot(3);
-                                    if (stk.isEmpty()) {
-                                        this.inventory.setStackInSlot(3, this.currentModel.getPredictionDrop().copyWithCount(this.predictionSuccess));
-                                    } else {
-                                        stk.grow(this.predictionSuccess);
-                                    }
-                                }
-                            }
-                            else { // Training
+                            if (this.trainingMode) { // Training
                                 ModelTier tier = this.currentModel.getTier();
                                 if (!tier.isMax() && HostileConfig.simModelUpgrade > 0) {
                                     int newData = this.currentModel.getData() + 1;
@@ -151,13 +137,29 @@ public class SimChamberTileEntity extends BlockEntity implements TickingBlockEnt
                                 }
                                 DataModelItem.setIters(model, DataModelItem.getIters(model) + 1);
                             }
+                            else { // Inference
+                                ItemStack stk = this.inventory.getStackInSlot(2);
+                                if (stk.isEmpty()) this.inventory.setStackInSlot(2, this.currentModel.getModel().baseDrop().copy());
+                                else stk.grow(1);
+
+                                if (this.predictionSuccess > 0) {
+                                    stk = this.inventory.getStackInSlot(3);
+                                    if (stk.isEmpty()) {
+                                        this.inventory.setStackInSlot(3, this.currentModel.getPredictionDrop().copyWithCount(this.predictionSuccess));
+                                    }
+                                    else stk.grow(this.predictionSuccess);
+                                }
+                            }
+
                             this.setChanged();
                         }
-                        else if (this.runtime != 0) {
+                        else { // runtime still > 0
                             this.energy.setEnergy(this.energy.getEnergyStored() - this.currentModel.getModel().simCost());
                             this.setChanged();
                         }
+
                     }
+
                     else {
                         this.failState = FailureState.REDSTONE;
                     }

--- a/src/main/resources/assets/hostilenetworks/lang/en_us.json
+++ b/src/main/resources/assets/hostilenetworks/lang/en_us.json
@@ -74,14 +74,26 @@
     "hostilenetworks.fail.faulty": "Insufficient data in model. Please insert a basic model or better",
     "hostilenetworks.fail.energy_mid_cycle": "Simulation progress paused\nSystem energy levels critical",
     "hostilenetworks.fail.redstone": "Simulation progress paused\nIncorrect redstone signal applied",
-    
-    "hostilenetworks.run.0": "> Launching runtime ",
-    "hostilenetworks.run.1": "> Iteration #%s started",
-    "hostilenetworks.run.2": "> Loading model from chip memory",
-    "hostilenetworks.run.3": "> Assessing threat level",
-    "hostilenetworks.run.4": "> Engaging enemy",
-    "hostilenetworks.run.5": "> Sequence prediction ",
-    "hostilenetworks.run.6": "> Processing results...",
+
+    "hostilenetworks.gui.mode.training": "Training Mode",
+    "hostilenetworks.gui.mode.inference": "Inference Mode",
+
+
+    "hostilenetworks.run.training.0": "> Launching runtime ",
+    "hostilenetworks.run.training.1": "> Training iteration #%s started",
+    "hostilenetworks.run.training.2": "> Loading model from chip memory",
+    "hostilenetworks.run.training.3": "> Assessing threat level",
+    "hostilenetworks.run.training.4": "> Engaging enemy",
+    "hostilenetworks.run.training.5": "> Collecting data",
+    "hostilenetworks.run.training.6": "> Processing results...",
+
+    "hostilenetworks.run.inference.0": "> Launching runtime ",
+    "hostilenetworks.run.inference.1": "> Model inference tier: ",
+    "hostilenetworks.run.inference.2": "> Loading model from chip memory",
+    "hostilenetworks.run.inference.3": "> Assessing threat level",
+    "hostilenetworks.run.inference.4": "> Engaging enemy",
+    "hostilenetworks.run.inference.5": "> Sequence prediction ",
+    "hostilenetworks.run.inference.6": "> Processing results...",
     
     "hostilenetworks.info.click_to_attune": "%s on an entity to %s",
     "hostilenetworks.info.attunment_disabled": "Model attunement is disabled",


### PR DESCRIPTION
Current minimal GUI toggle button in SimChamberScreen,T/I indicator on the button next to the previous redstone button
Added a trainingMode boolean toggle to Simulation Chamber, inference and training are mutually exclusive
Inference mode only generates the prediction drops, training mode only increments the model 
