### PR TITLE
Fix crash with WinterOverhaul by using vanilla's buffer source

### DIFF
--- a/src/main/java/dev/shadowsoffire/hostilenetworks/client/DataModelItemStackRenderer.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/client/DataModelItemStackRenderer.java
@@ -32,7 +32,6 @@ public class DataModelItemStackRenderer extends BlockEntityWithoutLevelRenderer 
         super(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels());
     }
 
-    private static final MultiBufferSource.BufferSource GHOST_ENTITY_BUF = MultiBufferSource.immediate(new ByteBufferBuilder(256));
     private static final ModelResourceLocation DATA_MODEL_BASE = ModelResourceLocation.standalone(HostileNetworks.loc("item/data_model_base"));
 
     @Override
@@ -65,8 +64,12 @@ public class DataModelItemStackRenderer extends BlockEntityWithoutLevelRenderer 
             matrix.scale(scale, scale, scale);
             matrix.translate(0.775, 0, -0.0825);
         }
-        irenderer.renderModelLists(base, stack, light, overlay, matrix, ItemRenderer.getFoilBufferDirect(GHOST_ENTITY_BUF, ItemBlockRenderTypes.getRenderType(stack, true), true, false));
-        GHOST_ENTITY_BUF.endBatch();
+        irenderer.renderModelLists(base, stack, light, overlay, matrix, ItemRenderer.getFoilBufferDirect(buf,
+                ItemBlockRenderTypes.getRenderType(stack, true), true, false));
+        if (!(buf instanceof MultiBufferSource.BufferSource source)) {
+            return;
+        }
+        source.endBatch();
         matrix.popPose();
         DynamicHolder<DataModel> model = DataModelItem.getStoredModel(stack);
         if (model.isBound()) {
@@ -76,13 +79,14 @@ public class DataModelItemStackRenderer extends BlockEntityWithoutLevelRenderer 
                 ent.tickCount = Minecraft.getInstance().player.tickCount;
             }
             if (ent != null) {
-                renderEntityInInventory(matrix, type, ent, display);
+                renderEntityInInventory(matrix, type, ent, display, source);
             }
         }
     }
 
     @SuppressWarnings("deprecation")
-    public static void renderEntityInInventory(PoseStack matrix, ItemDisplayContext type, Entity entity, DisplayEntity display) {
+    public static void renderEntityInInventory(PoseStack matrix, ItemDisplayContext type, Entity entity, DisplayEntity display,
+                                               MultiBufferSource.BufferSource source) {
         matrix.pushPose();
         matrix.translate(0.5, 0.5, 0.5);
         float scale = display.scale();
@@ -138,7 +142,7 @@ public class DataModelItemStackRenderer extends BlockEntityWithoutLevelRenderer 
 
         EntityRenderDispatcher entityrenderermanager = Minecraft.getInstance().getEntityRenderDispatcher();
         entityrenderermanager.setRenderShadow(false);
-        MultiBufferSource.BufferSource rtBuffer = GHOST_ENTITY_BUF;
+        MultiBufferSource.BufferSource rtBuffer = source;
         WeirdRenderThings.translucent = true;
         RenderSystem.runAsFancy(() -> {
             entityrenderermanager.render(entity, display.xOffset(), display.yOffset(), display.zOffset(), 0.0F, Minecraft.getInstance().getTimer().getGameTimeDeltaPartialTick(true), matrix,


### PR DESCRIPTION
Fix #106 by switching away from the custom `MultiBufferSource.BufferSource GHOST_ENTITY_BUF` into using vanilla's `MultiBufferSource`.  I don't love the code but the alternative is creating a BufferSource with immediate and reusing vanilla's map as seen in `RenderBuffers`. If you see something cleaner, by all means go for it.

The issue behind this is that vanilla doesn't take very well reusing the same buffer source repeteadly with different rendertypes and without the `fixedBuffers` map, which is what happens when `MultiBufferSource.immediate` is used and not `MultiBufferSource.immediateWithBuffers` which is what vanilla uses in `RenderBuffers`. 

In particular, this blows up with this WinterOverhaul and GeckoLib because multiple rendertypes are used with the same buffer source. As you can see in the code image, `startedBuilders` is used regularly, but when there's no `fixedBuffers` ( _immediate_ and not _immediateWithBuffers_), the code simply `endBatch`es the last rendertype using it, which leads to the storage of  buffer thats not building anymore and NEVER removed from the map IF the rendertype from earlier does not match the current rendertype. The removal only happens through `put` overriding. Probably a vanilla bug but vanilla doesn't do these weird things with rendering.

The offending vanilla code. Ignore the red arrow and focus on the red branch,  its where the bug lives: 
<img width="1349" height="732" alt="Figure1" src="https://github.com/user-attachments/assets/7d2fffff-42ca-4e0f-b775-3c0ed1fcc943" />

What WinterOverhaul triggers and should be easy to replicate is:

- call to render something with one render type, 
- render something else with a second rendertype,
- then render a third thing with the first rendertype

The lack of the `fixedBuffers` map to recover is what causes the access to a buffersource that should be building but isn't.

Working screenshot with WinterOverhaul: 
<img width="610" height="369" alt="Figure1" src="https://github.com/user-attachments/assets/509d7020-5905-4784-bc9f-1eec459bf664"/>

PD: I tried cloning your repo but got:

```
SourceSet with name 'test' not found.
> SourceSet with name 'test' not found.
```
Fixed it by removing the following from the build.gradle: 
```groovy
if (!project.enableTests.toBoolean()) {
    sourceSets.remove(sourceSets.test)
}
```

I merely stand on the shoulder of a giant :P Its not my aim to take credit for the code analysis or the fix, just merely being a messenger.