### PR TITLE
 Fix Data Center I/O ports after server restart

### DIFF
--- a/src/main/java/dev/shadowsoffire/hostilenetworks/tile/DataCenterIOPortTileEntity.java
+++ b/src/main/java/dev/shadowsoffire/hostilenetworks/tile/DataCenterIOPortTileEntity.java
@@ -24,6 +24,9 @@ public class DataCenterIOPortTileEntity extends BlockEntity {
     @Nullable
     protected BlockPos ownerPos = null;
 
+    /** Tracks the post-load capability refresh after the controller has revalidated its shell. */
+    private boolean refreshedCaps = false;
+
     public DataCenterIOPortTileEntity(BlockPos pos, BlockState state) {
         super(Hostile.TileEntities.IO_PORT, pos, state);
     }
@@ -38,17 +41,26 @@ public class DataCenterIOPortTileEntity extends BlockEntity {
     }
 
     public void setOwner(BlockPos pos) {
-        if (pos.equals(this.ownerPos)) return;
+        if (pos.equals(this.ownerPos)) {
+            if (!this.refreshedCaps) this.refreshCapabilities();
+            return;
+        }
         this.ownerPos = pos.immutable();
         this.sync();
-        if (this.level != null) this.level.invalidateCapabilities(this.worldPosition);
+        this.refreshCapabilities();
     }
 
     public void clearOwner() {
         if (this.ownerPos == null) return;
         this.ownerPos = null;
         this.sync();
-        if (this.level != null) this.level.invalidateCapabilities(this.worldPosition);
+        this.refreshCapabilities();
+    }
+
+    private void refreshCapabilities() {
+        if (this.level == null) return;
+        this.level.invalidateCapabilities(this.worldPosition);
+        this.refreshedCaps = true;
     }
 
     /** Resolves to the owning controller iff it's loaded and its shell is currently valid; otherwise {@code null}. */


### PR DESCRIPTION
## Summary

Fixes Data Center I/O ports failing to resume item or energy transfer after restarting a dedicated or singleplayer server.

## Problem

I/O ports persist their controller position, but the controller must revalidate its multiblock shell after loading. If automation queries a port before that validation completes, NeoForge can cache a missing capability.

When the shell is later validated, `setOwner` receives the already-persisted controller position and previously returned without invalidating that cached result. Cycling the port mode fixed the issue because doing so invalidated its capabilities.

## Changes

- Invalidate port capabilities once after the controller completes its post-load shell validation, even when the owner position is unchanged.
- Track the post-load refresh to avoid invalidating capabilities during every periodic shell check.
- Centralize capability invalidation for owner assignment and removal.

Edit: This should address issue #123 